### PR TITLE
ddd/gdb: Fix machine code disassembling

### DIFF
--- a/ddd/GDBAgent.C
+++ b/ddd/GDBAgent.C
@@ -3200,7 +3200,7 @@ string GDBAgent::disassemble_command(string start, const char *end) const
     {
         string end_( end );
 	normalize_address(end_);
-	cmd += ' ';
+	cmd += ',';
 	cmd += end_;
     }
     return cmd;


### PR DESCRIPTION
Gdb expects the start and end address to be separated by a comma in the
`disassemble` command.