### PR TITLE
Fix out-of-bounds preference parsing

### DIFF
--- a/ddd/userinfo.C
+++ b/ddd/userinfo.C
@@ -84,9 +84,9 @@ static char *email_from_preferences(const char *home, const char *dotrc, const c
 
 		char *s = line + strlen(tag);
 		char *t = buffer;
-		while (is_junk(*s))
+		while (*s != '\0' && is_junk(*s))
 		    s++;
-		while (!is_junk(*s) && *s != '\0')
+		while (*s != '\0' && !is_junk(*s))
 		    *t++ = tolower(*s++);
 		*t++ = '\0';
 		fclose(fp);


### PR DESCRIPTION
## Summary

- Stop preference parsing at the string terminator before classifying separator characters.
- Preserve the existing behavior for whitespace and other separators.

## Problem

`email_from_preferences()` skips leading separator characters with `is_junk()`. Because `is_junk('\0')` returns true, a matching preference entry with no value, such as `personal_mail_address=` followed by a newline, advances past the terminating null byte and continues reading outside the input string. This is undefined behavior and can result in a crash or the use of unrelated memory as an email address.

## Fix

Check for `\0` before calling `is_junk()` in both parsing loops. An empty preference value now produces an empty string, which the existing validation rejects before trying the next email source.

## Validation

- `git diff --check`
- `cppcheck --enable=warning --std=c++03 --language=c++ --quiet --suppress=missingIncludeSystem ddd/userinfo.C` (no findings in the changed code)
